### PR TITLE
Refactor: JWT 토큰 refresh 로직 리팩토링

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -8,16 +8,14 @@ import { Route, Routes } from 'react-router-dom';
 import Calendar from './pages/Calendar';
 import Login from './pages/Login';
 import Register from './pages/Register';
-import { useSelector, useDispatch } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import { useQuery, useQueryClient } from 'react-query';
 import { silentRefresh } from './api/authAPI';
-import axios from 'axios';
 import { userLogin } from './modules/user';
 import NotFound from './pages/NotFound';
 
 function App() {
   const dispatch = useDispatch();
-  const isLogin = useSelector((state) => state.user.isLogin);
   const queryClient = useQueryClient();
 
   // 새로고침 시 silent refresh
@@ -26,27 +24,7 @@ function App() {
     refetchOnMount: false,
     refetchOnReconnect: false,
     onSuccess: (res) => {
-      const { accessToken, user_id, user_name } = res.data;
-      axios.defaults.headers.common['Authorization'] = `Bearer ${accessToken}`;
-      dispatch(userLogin({ user_id, user_name }));
-      queryClient.invalidateQueries('diaries');
-    },
-    onError: (err) => {
-      console.log(err);
-    },
-  });
-
-  // 로그인 상태에서 자동으로 token 갱신
-  useQuery('user', silentRefresh, {
-    refetchOnWindowFocus: false,
-    refetchOnMount: false,
-    refetchOnReconnect: false,
-    enabled: !!isLogin, // 로그인 상태일때만 갱신
-    refetchInterval: 60 * 60 * 1000 - 60000,
-    refetchIntervalInBackground: true,
-    onSuccess: (res) => {
-      const { accessToken, user_id, user_name } = res.data;
-      axios.defaults.headers.common['Authorization'] = `Bearer ${accessToken}`;
+      const { user_id, user_name } = res.data;
       dispatch(userLogin({ user_id, user_name }));
       queryClient.invalidateQueries('diaries');
     },

--- a/client/src/api/authAPI.js
+++ b/client/src/api/authAPI.js
@@ -1,21 +1,21 @@
-import axios from 'axios';
+import axios from './axiosInstance';
 
 export const silentRefresh = async () => {
-  const response = await axios.get('/api/auth/silent-refresh');
+  const response = await axios.get('/auth/silent-refresh');
   return response;
 };
 
 export const onLogin = async (infos) => {
-  const response = await axios.post('/api/auth/login', infos);
+  const response = await axios.post('/auth/login', infos);
   return response;
 };
 
 export const onLogout = async () => {
-  const response = await axios.post('/api/auth/logout', {});
+  const response = await axios.post('/auth/logout');
   return response;
 };
 
 export const onRegister = async (infos) => {
-  const response = await axios.post('/api/auth/register', infos);
+  const response = await axios.post('/auth/register', infos);
   return response;
 };

--- a/client/src/api/axiosInstance.js
+++ b/client/src/api/axiosInstance.js
@@ -1,0 +1,45 @@
+import axios from 'axios';
+
+const instance = axios.create({
+  baseURL: 'http://localhost:5000/api',
+  headers: {
+    'Content-Type': 'application/json',
+  },
+  withCredentials: true,
+});
+
+instance.interceptors.response.use(
+  (res) => {
+    const accessToken = res.data.accessToken;
+    if (accessToken) {
+      instance.defaults.headers.common[
+        'Authorization'
+      ] = `Bearer ${accessToken}`;
+    }
+
+    return res;
+  },
+  async (err) => {
+    const originConfig = err.config;
+
+    if (err.response) {
+      if (
+        err.response.status === 401 &&
+        err.response.data.message === 'Token Expired'
+      ) {
+        try {
+          const { data } = await instance.get('/auth/silent-refresh');
+
+          originConfig.headers['Authorization'] = `Bearer ${data.accessToken}`;
+          return instance(originConfig);
+        } catch (_err) {
+          return Promise.reject(_err);
+        }
+      }
+    }
+
+    return Promise.reject(err);
+  }
+);
+
+export default instance;

--- a/client/src/api/diaryAPI.js
+++ b/client/src/api/diaryAPI.js
@@ -1,7 +1,7 @@
-import axios from 'axios';
+import axios from './axiosInstance';
 
 export const onWrite = async (infos) => {
-  const response = await axios.post('/api/diary', infos);
+  const response = await axios.post('/diary', infos);
   return response;
 };
 
@@ -9,7 +9,7 @@ export const getDiaries = async (payload) => {
   const { from, to } = payload;
   if (from === null) return [];
 
-  const response = await axios.get('/api/diary', {
+  const response = await axios.get('/diary', {
     params: {
       from: from.toDate(),
       to: to.toDate(),
@@ -19,7 +19,7 @@ export const getDiaries = async (payload) => {
 };
 
 export const onDelete = async (id) => {
-  const response = await axios.delete(`/api/diary/${id}`);
+  const response = await axios.delete(`/diary/${id}`);
   return response;
 };
 

--- a/client/src/components/Auth/AuthForm.js
+++ b/client/src/components/Auth/AuthForm.js
@@ -78,8 +78,7 @@ function AuthForm({ type }) {
 
   const { mutate: login } = useMutation((infos) => onLogin(infos), {
     onSuccess: (res) => {
-      const { accessToken, user_id, user_name, message } = res.data;
-      axios.defaults.headers.common['Authorization'] = `Bearer ${accessToken}`;
+      const { user_id, user_name, message } = res.data;
       dispatch(userLogin({ user_id, user_name }));
       alert(message);
       navigate('/');

--- a/controllers/auth.controller.js
+++ b/controllers/auth.controller.js
@@ -10,12 +10,13 @@ module.exports = {
       const accessToken = makeAccessToken(id);
       const refreshToken = makeRefreshToken(id);
 
-      const { user_id, user_name } = userService.findOneByFilter({
+      const { user_id, user_name } = await userService.findOneByFilter({
         user_id: id,
       });
       res.cookie('refreshToken', refreshToken, {
         httpOnly: true,
       });
+
       res.status(STATUS_CODE.OK).json({
         accessToken,
         user_id,

--- a/utils/jwt.js
+++ b/utils/jwt.js
@@ -1,4 +1,5 @@
 const jwt = require('jsonwebtoken');
+const { UnauthorizedError } = require('./error');
 
 module.exports = {
   verifyToken: (token) => {
@@ -6,6 +7,9 @@ module.exports = {
       const decoded = jwt.verify(token, process.env.JWT_SECRET_KEY);
       return decoded;
     } catch (err) {
+      if (err.name === 'TokenExpiredError') {
+        throw new UnauthorizedError('Token Expired');
+      }
       throw err;
     }
   },
@@ -17,7 +21,7 @@ module.exports = {
         },
         process.env.JWT_SECRET_KEY,
         {
-          expiresIn: '1h',
+          expiresIn: '30s',
         }
       );
     } catch (err) {


### PR DESCRIPTION
# :eyes: What is this PR?

JWT refresh 로직 axios interceptor를 통한 리팩토링

# :pencil: Changes

- JWT token verify시 토큰만료일 시 token expired 오류 throw
- 클라이언트 측 api요청시 기존 axios에서 custom axios instance 모듈 사용으로 변경
- JWT 관련 로직을 `axiosInstance.js` 한 곳에서 모두 처리하도록 클라이언트 API 요청 로직 개선
- axios interceptor를 통해 response 성공 시 access token 설정 로직 처리
- axios interceptor를 통해 오류 발생시 token 만료오류라면 refresh 로직 처리 

# :camera: Attachment
